### PR TITLE
refactor/system info

### DIFF
--- a/src/core/system.py
+++ b/src/core/system.py
@@ -1,4 +1,5 @@
 import os
+import datetime
 import platform
 import subprocess
 import time
@@ -8,8 +9,39 @@ import re
 from src.utilities.utils import print_bold_kv, print_title
 
 
-def get_last_boot_time() -> float:
-    """Returns the last boot time as a float for macOS."""
+# def get_last_boot_time() -> float:
+#     """Returns the last boot time as a float for macOS."""
+#     if platform.system() == "Darwin":
+#         try:
+#             result = subprocess.run(
+#                 ["sysctl", "-n", "kern.boottime"],
+#                 capture_output=True,
+#                 text=True,
+#                 check=True,
+#             ).stdout.strip()
+#             if match := re.search(r"sec = (\d+)", result):
+#                 return float(match[1])
+#             else:
+#                 raise ValueError("Could not parse kern.boottime output")
+#         except (subprocess.CalledProcessError, ValueError) as e:
+#             print(f"An error occurred while getting last boot time: {e}")
+#             return 0.0
+#     else:
+#         try:
+#             result = subprocess.run(
+#                 ["uptime", "-s"],
+#                 capture_output=True,
+#                 text=True,
+#                 check=True,
+#             ).stdout.strip()
+#             return float(result)
+#         except subprocess.CalledProcessError as e:
+#             print(f"An error occurred while getting last boot time: {e}")
+#             return 0.0
+
+
+def get_last_boot_time() -> str:
+    """Returns the last boot time as a date and time string."""
     if platform.system() == "Darwin":
         try:
             result = subprocess.run(
@@ -19,27 +51,30 @@ def get_last_boot_time() -> float:
                 check=True,
             ).stdout.strip()
             if match := re.search(r"sec = (\d+)", result):
-                return float(match[1])
+                boot_timestamp = int(match[1])
+                return datetime.datetime.fromtimestamp(boot_timestamp).strftime(
+                    "%Y-%m-%d %H:%M:%S"
+                )
             else:
                 raise ValueError("Could not parse kern.boottime output")
         except (subprocess.CalledProcessError, ValueError) as e:
             print(f"An error occurred while getting last boot time: {e}")
-            return 0.0
-    else:
+            return "Error obtaining last boot time"
+    else:  # Assuming this else branch is for Linux
         try:
-            result = subprocess.run(
+            return subprocess.run(
                 ["uptime", "-s"],
                 capture_output=True,
                 text=True,
                 check=True,
             ).stdout.strip()
-            return float(result)
         except subprocess.CalledProcessError as e:
             print(f"An error occurred while getting last boot time: {e}")
-            return 0.0
+            return "Error obtaining last boot time"
 
 
 def get_system_uptime() -> str:
+    """Returns the system uptime as a string."""
     if platform.system() == "Linux":
         try:
             uptime_seconds = time.time() - os.stat("/proc/1").st_ctime

--- a/src/core/system.py
+++ b/src/core/system.py
@@ -95,9 +95,7 @@ def get_system_info() -> dict:
     }
 
     system_info["uptime"] = get_system_uptime()
-    system_info["last_boot_date"] = time.strftime(
-        "%Y-%m-%d %H:%M:%S", time.localtime(get_last_boot_time())
-    )
+    system_info["last_boot_date"] = get_last_boot_time()
     if system_info["os_type"] == "Linux":
         import distro  # distro is a Linux-specific package
 

--- a/src/core/system.py
+++ b/src/core/system.py
@@ -3,7 +3,7 @@ import platform
 import subprocess
 import time
 import re
-import distro
+
 
 from src.utilities.utils import print_bold_kv, print_title
 
@@ -82,9 +82,9 @@ def get_system_info() -> dict:
     }
 
     if system_info["os_type"] == "Linux":
-        system_info["dist"] = distro.name(
-            pretty=True
-        )  # This should include the codename
+        import distro  # distro is a Linux-specific package
+
+        system_info["dist"] = distro.name()
         system_info["dist_version"] = distro.version()
         system_info["uptime"] = get_system_uptime()
         system_info["users_nb"] = get_user_count_unix("/home")

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,8 +1,5 @@
 import pytest
-import subprocess
 from unittest.mock import patch, MagicMock
-import os
-import time
 from src.core.system import get_last_boot_time_macos, get_system_uptime, get_user_count_unix, get_system_info
 
 # Test get_last_boot_time_macos

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,13 +1,25 @@
-import pytest
+import subprocess
+import platform
 from unittest.mock import patch, MagicMock
-from src.core.system import get_last_boot_time_macos, get_system_uptime, get_user_count_unix, get_system_info
+import pytest
+from src.core.system import (
+    get_last_boot_time_macos,
+    get_system_uptime,
+    get_user_count_unix,
+    get_system_info,
+)
+
 
 # Test get_last_boot_time_macos
-@pytest.mark.parametrize("output,expected", [
-    ("{ sec = 1625097600, usec = 0 }", 1625097600.0),  # ID: valid-output
-    ("", 0.0),  # ID: empty-output
-    ("invalid output", 0.0),  # ID: invalid-output
-], ids=["valid-output", "empty-output", "invalid-output"])
+@pytest.mark.parametrize(
+    "output,expected",
+    [
+        ("{ sec = 1625097600, usec = 0 }", 1625097600.0),  # ID: valid-output
+        ("", 0.0),  # ID: empty-output
+        ("invalid output", 0.0),  # ID: invalid-output
+    ],
+    ids=["valid-output", "empty-output", "invalid-output"],
+)
 def test_get_last_boot_time_macos(output, expected):
     with patch("subprocess.run") as mocked_run:
         mocked_run.return_value = MagicMock(stdout=output)
@@ -18,27 +30,61 @@ def test_get_last_boot_time_macos(output, expected):
         # Assert
         assert result == expected
 
-# Test get_system_uptime
-@pytest.mark.parametrize("output,expected", [
-    ("13:05  up 3 days, 18:53, 5 users", "13:05  up 3 days,  18:53"),  # ID: normal-case
-    ("", ""),  # ID: empty-output
-    ("uptime: unexpected output", "uptime: unexpected output"),  # ID: unexpected-output
-], ids=["normal-case", "empty-output", "unexpected-output"])
-def test_get_system_uptime(output, expected):
-    with patch("subprocess.run") as mocked_run:
-        mocked_run.return_value = MagicMock(stdout=output)
 
-        # Act
-        result = get_system_uptime()
+# # Test get_system_uptime
+# @pytest.mark.parametrize("output,expected", [
+#     ("13:05  up 3 days, 18:53, 5 users", "13:05  up 3 days,  18:53"),  # ID: normal-case
+#     ("", ""),  # ID: empty-output
+#     ("uptime: unexpected output", "uptime: unexpected output"),  # ID: unexpected-output
+# ], ids=["normal-case", "empty-output", "unexpected-output"])
+# def test_get_system_uptime(output, expected):
+#     with patch("subprocess.run") as mocked_run:
+#         mocked_run.return_value = MagicMock(stdout=output)
 
-        # Assert
-        assert result == expected
+#         # Act
+#         result = get_system_uptime()
+
+#         # Assert
+#         assert result == expected
+
+
+@pytest.mark.skipif(platform.system() != "Linux", reason="Running on non-Linux system")
+def test_get_system_uptime_linux():
+    with patch("platform.system", return_value="Linux"), patch(
+        "os.stat", return_value=MagicMock(st_ctime=1000)
+    ), patch("time.time", return_value=2000):
+        assert get_system_uptime() == "0 days, 0 hours, 16 minutes"
+
+    with patch("platform.system", return_value="Linux"), patch(
+        "os.stat", side_effect=Exception("Error")
+    ):
+        assert get_system_uptime() == "Error in obtaining uptime"
+
+
+@pytest.mark.skipif(
+    platform.system() != "Darwin", reason="Running on non-Darwin system"
+)
+def test_get_system_uptime_darwin():
+    with patch("platform.system", return_value="Darwin"), patch(
+        "subprocess.run", return_value=MagicMock(stdout="10:00 up 1 day, 2:00")
+    ):
+        assert get_system_uptime() == "10:00 up 1 day,  2:00"
+
+    with patch("platform.system", return_value="Darwin"), patch(
+        "subprocess.run", side_effect=subprocess.CalledProcessError(1, "uptime")
+    ):
+        assert get_system_uptime() == "Error in obtaining uptime"
+
 
 # Test get_user_count_unix
-@pytest.mark.parametrize("path,dirs,expected", [
-    ("/Users", ["user1", "Shared", "user2"], 2),  # ID: normal-case
-    ("/invalid/path", [], 0),  # ID: invalid-path
-], ids=["normal-case", "invalid-path"])
+@pytest.mark.parametrize(
+    "path,dirs,expected",
+    [
+        ("/Users", ["user1", "Shared", "user2"], 2),  # ID: normal-case
+        ("/invalid/path", [], 0),  # ID: invalid-path
+    ],
+    ids=["normal-case", "invalid-path"],
+)
 def test_get_user_count_unix(path, dirs, expected):
     with patch("os.listdir") as mocked_listdir, patch("os.path.isdir") as mocked_isdir:
         mocked_listdir.return_value = dirs
@@ -50,23 +96,59 @@ def test_get_user_count_unix(path, dirs, expected):
         # Assert
         assert result == expected
 
+
 # TODO: test is currently missing uptime and last_boot_time
-@pytest.mark.parametrize("os_type,expected_keys", [
-    ("Linux", ["os_type", "hostname", "kernel_info", "architecture", "dist", "dist_version", "users_nb", "current_date"]),  # ID: linux
-    ("Darwin", ["os_type", "hostname", "kernel_info", "architecture", "dist", "dist_version", "users_nb", "current_date"]),  # ID: darwin
-], ids=["linux", "darwin"])
+@pytest.mark.parametrize(
+    "os_type,expected_keys",
+    [
+        (
+            "Linux",
+            [
+                "os_type",
+                "hostname",
+                "kernel_info",
+                "architecture",
+                "dist",
+                "dist_version",
+                "users_nb",
+                "current_date",
+            ],
+        ),  # ID: linux
+        (
+            "Darwin",
+            [
+                "os_type",
+                "hostname",
+                "kernel_info",
+                "architecture",
+                "dist",
+                "dist_version",
+                "users_nb",
+                "current_date",
+            ],
+        ),  # ID: darwin
+    ],
+    ids=["linux", "darwin"],
+)
 def test_get_system_info(os_type, expected_keys):
 
-    with patch("platform.system", return_value=os_type), \
-         patch("platform.node", return_value="test_hostname"), \
-         patch("platform.uname", return_value=MagicMock(release="test_release")), \
-         patch("platform.machine", return_value="test_machine"), \
-         patch("platform.mac_ver", return_value=("10.15.1", "", "")), \
-         patch("os.listdir"), \
-         patch("os.path.isdir", return_value=True), \
-         patch("time.time", return_value=1625097600), \
-         patch("distro.name", return_value="Ubuntu"), \
-         patch("distro.version", return_value="20.04"):
+    with patch("platform.system", return_value=os_type), patch(
+        "platform.node", return_value="test_hostname"
+    ), patch("platform.uname", return_value=MagicMock(release="test_release")), patch(
+        "platform.machine", return_value="test_machine"
+    ), patch(
+        "platform.mac_ver", return_value=("10.15.1", "", "")
+    ), patch(
+        "os.listdir"
+    ), patch(
+        "os.path.isdir", return_value=True
+    ), patch(
+        "time.time", return_value=1625097600
+    ), patch(
+        "distro.name", return_value="Ubuntu"
+    ), patch(
+        "distro.version", return_value="20.04"
+    ):
 
         # Act
         result = get_system_info()
@@ -74,6 +156,3 @@ def test_get_system_info(os_type, expected_keys):
         # Assert
         for key in expected_keys:
             assert key in result
-
-
-

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -47,29 +47,55 @@ from src.core.system import (
 #         # Assert
 #         assert result == expected
 
-@pytest.mark.skipif(platform.system() != "Darwin", reason="Running on non-Darwin system")
-def test_get_last_boot_time_darwin():
-    with patch("platform.system", return_value="Darwin"), patch(
-        "subprocess.run", return_value=MagicMock(stdout="kern.boottime = { sec = 1625097600, usec = 0 } Mon Jun  1 00:00:00 2020")
-    ):
-        assert get_last_boot_time() == 1625097600.0
+# @pytest.mark.skipif(platform.system() != "Darwin", reason="Running on non-Darwin system")
+# def test_get_last_boot_time_darwin():
+#     with patch("platform.system", return_value="Darwin"), patch(
+#         "subprocess.run", return_value=MagicMock(stdout="kern.boottime = { sec = 1625097600, usec = 0 } Mon Jun  1 00:00:00 2020")
+#     ):
+#         assert get_last_boot_time() == 1625097600.0
 
-    with patch("platform.system", return_value="Darwin"), patch(
-        "subprocess.run", side_effect=subprocess.CalledProcessError(1, "sysctl")
-    ):
-        assert get_last_boot_time() == 0.0
+#     with patch("platform.system", return_value="Darwin"), patch(
+#         "subprocess.run", side_effect=subprocess.CalledProcessError(1, "sysctl")
+#     ):
+#         assert get_last_boot_time() == 0.0
 
-@pytest.mark.skipif(platform.system() != "Linux", reason="Running on non-Linux system")
+# @pytest.mark.skipif(platform.system() != "Linux", reason="Running on non-Linux system")
+# def test_get_last_boot_time_linux():
+#     with patch("platform.system", return_value="Linux"), patch(
+#         "subprocess.run", return_value=MagicMock(stdout="2020-06-01 00:00:00")
+#     ):
+#         assert get_last_boot_time() == 1590969600.0
+
+#     with patch("platform.system", return_value="Linux"), patch(
+#         "subprocess.run", side_effect=subprocess.CalledProcessError(1, "uptime")
+#     ):
+#         assert get_last_boot_time() == 0.0
+
+
+# Test for macOS
+@pytest.mark.skipif(
+    platform.system() != "Darwin", reason="Test only applicable on macOS"
+)
+def test_get_last_boot_time_macos():
+    with patch("subprocess.run") as mocked_run:
+        mocked_run.return_value = subprocess.CompletedProcess(
+            args=["sysctl", "-n", "kern.boottime"],
+            returncode=0,
+            stdout="sec = 1640995200\n",
+        )
+        assert get_last_boot_time() == "2021-12-31 19:00:00"
+
+
+# Test for Linux
+@pytest.mark.skipif(
+    platform.system() != "Linux", reason="Test only applicable on Linux"
+)
 def test_get_last_boot_time_linux():
-    with patch("platform.system", return_value="Linux"), patch(
-        "subprocess.run", return_value=MagicMock(stdout="2020-06-01 00:00:00")
-    ):
-        assert get_last_boot_time() == 1590969600.0
-
-    with patch("platform.system", return_value="Linux"), patch(
-        "subprocess.run", side_effect=subprocess.CalledProcessError(1, "uptime")
-    ):
-        assert get_last_boot_time() == 0.0
+    with patch("subprocess.run") as mocked_run:
+        mocked_run.return_value = subprocess.CompletedProcess(
+            args=["uptime", "-s"], returncode=0, stdout="2024-04-10 12:34:56\n"
+        )
+        assert get_last_boot_time() == "2024-04-10 12:34:56"
 
 
 @pytest.mark.skipif(platform.system() != "Linux", reason="Running on non-Linux system")


### PR DESCRIPTION
- **feat: Add distro module to get system information and update system uptime calculation**
- **fix(system.py): remove unused import statement for distro package feat(system.py): import distro package within the Linux-specific block to ensure it is only imported when needed feat(test_system.py): refactor test_get_system_uptime to include separate test cases for Linux and Darwin systems feat(test_system.py): add skipif decorators to test_get_system_uptime_linux and test_get_system_uptime_darwin feat(test_system.py): refactor test_get_user_count_unix to include multiple test cases with parameters feat(test_system.py): refactor test_get_system_info to include separate test cases for Linux and Darwin systems**
- **refactor(system.py): rename get_last_boot_time_macos to get_last_boot_time and add support for retrieving last boot time on non-Darwin systems feat(system.py): add logic to retrieve last boot time using 'uptime -s' command on non-Darwin systems test(system.py): add tests for get_last_boot_time function for both Darwin and non-Darwin systems**
- **refactor: Simplify retrieving last boot date in system information**
- **feat(system.py): add support for retrieving last boot time as a date and time string feat(system.py): improve error handling and return meaningful messages for obtaining last boot time feat(system.py): add function to get system uptime as a string test(system.py): add tests for retrieving last boot time on macOS and Linux platforms**
